### PR TITLE
fix: fix count and latency metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ metrics_app = make_asgi_app()
 
 
 # -----------------------------------------------------------------------
+# WARNING: Revise
 @app.middleware("http")
 async def add_process_time_header(request: Request, call_next):
     start_time = time.perf_counter()
@@ -30,8 +31,7 @@ async def add_process_time_header(request: Request, call_next):
 
     method = request.method
     status_code_str = str(response.status_code)
-    route = request.scope.get("route")
-    endpoint = route.path if route else "unmatched_route"
+    endpoint = request.url.path
 
     REQUEST_COUNT.labels(method=method, endpoint=endpoint, status=status_code_str).inc()
 


### PR DESCRIPTION
All the endpoints are showing `endpoint="unmatched_route"`, the problem occurs, because the `request.scope.get("route"` are returning `None` in all requests. 

This happens, because the middleware run before the FastAPI resolve the route. 

I use the simple solution, trade the `request.scope.get("route"` -> `request.url.path`.

In the beginning I think the `request.scope...` wouldn't be a problem, the LSP don't alert nothing but when I open the `/metrics` I see so much problem 😂.

