### PR TITLE
feat: add environment variables for database and Redis hosts closes #59

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,32 +4,37 @@
 
 name: CI # Workflow name
 
-on: # Defines WHEN the workflow runs
-  push: # Triggers when code is pushed
-    branches: [ "main" ] # Only runs if the push is to the "main" branch
-  pull_request: # Triggers when a Pull Request is opened, upadate, or reopened
+on:
+  # Defines WHEN the workflow runs
+  push:
+    # Triggers when code is pushed
+    branches: ["main"] # Only runs if the push is to the "main" branch
+  pull_request:
+    # Triggers when a Pull Request is opened, upadate, or reopened
 
-jobs: # Group of jobs to be executed.
+jobs:
+  # Group of jobs to be executed.
   build:
     runs-on: ubuntu-latest
 
-    services: # Extra containers that run alongside the job
-      postgres: # Service name (Used internally for reference)
+    services:
+      # Extra containers that run alongside the job
+      postgres:
+        # Service name (Used internally for reference)
         image: postgres:17 # Docker image for PostgreSQL
-        env: # Environment variables to configure the database
+        env:
+          # Environment variables to configure the database
           POSTGRES_USER: deploy_tracker
-          POSTGRES_PASSWORD: password 
+          POSTGRES_PASSWORD: password
           POSTGRES_DB: deploy_tracker
         ports:
           - 5432:5432 # Container port of db
         options: >-
-          --health-cmd="pg_isready -U deploy_tracker"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+          --health-cmd="pg_isready -U deploy_tracker" --health-interval=10s
+          --health-timeout=5s --health-retries=5
 
     steps:
-      - name: Checkout code 
+      - name: Checkout code
         uses: actions/checkout@v5
 
       - name: Use Python
@@ -46,8 +51,10 @@ jobs: # Group of jobs to be executed.
         run: python -m ruff check .
 
       - name: Run tests
+        env:
+          DB_HOST: localhost
+          REDIS_HOST: localhost
         run: pytest
 
       - name: Build Docker Image
         run: docker build -t deploy-tracker .
-

--- a/cache.py
+++ b/cache.py
@@ -3,10 +3,12 @@
 
 import redis
 import json
+import os
 
 # -------------------------------------------------
-
-r = redis.Redis(host="redis", port=6379, decode_responses=True)
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+# -------------------------------------------------
+r = redis.Redis(host=REDIS_HOST, port=6379, decode_responses=True)
 # decode_responses means -> Redis returns strings instead of bytes, which is easier to work with. -------------------------------------------------
 # json.dumps() -> Convert Python(dicts and lists) to JSON-string.
 # json.loads() -> Convert JSON string back to python

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,12 +1,13 @@
 from celery import Celery
+from cache import REDIS_HOST
 
 # -------------------------------------------------
 
 # the name can't have uppercase or space.
 celery_app = Celery(
     "deploy_tracker",
-    broker="redis://redis:6379/0",
-    backend="redis://redis:6379/0",
+    broker=f"redis://{REDIS_HOST}:6379/0",
+    backend=f"redis://{REDIS_HOST}:6379/0",
 )
 
 # Write about: What is Celery Beat? What the function of Celery Beat?
@@ -14,7 +15,9 @@ celery_app.conf.beat_schedule = {
     "health_check_30s": {
         "task": "tasks.health_checker",
         "schedule": 30.0,  # seconds
-        "args": (1,),
+        "args": (
+            1,
+        ),  # TODO: Dynamically check all registered applications instead of hardcoded id
     },
 }
 

--- a/database.py
+++ b/database.py
@@ -2,11 +2,16 @@
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, DeclarativeBase
+import os
 
+# ------------------------------------------------------
+
+DB_HOST = os.getenv("DB_HOST", "db")
+
+# ------------------------------------------------------
 engine = create_engine(
-    "postgresql+psycopg2://deploy_tracker:password@db/deploy_tracker"
-)  # hostname always `localhost`. | In Docker Compose, the hostname will change to the container name.
-
+    f"postgresql+psycopg2://deploy_tracker:password@{DB_HOST}/deploy_tracker"
+)  # DB_HOST defaults to "db" for Docker Compose, override with env variable for other environments.
 # ------------------------------------------------------
 
 


### PR DESCRIPTION
## What changed
- Added environment variables for DB_HOST and REDIS_HOST in database.py, cache.py, and celery_app.py
- Updated ci.yml to pass localhost as host for tests in GitHub Actions

## Why
- Previously, hostnames were hardcoded ("db" and "redis") which only worked inside Docker Compose
- GitHub Actions CI/CD was failing because it runs PostgreSQL and Redis on localhost, not in named containers
- Now the code defaults to Docker Compose service names but can be overridden via environment variables for any environment (CI, local development, production)

## Files changed
- database.py: DB_HOST with default "db"
- cache.py: REDIS_HOST with default "redis"
- celery_app.py: imports REDIS_HOST from cache.py
- ci.yml: sets DB_HOST=localhost and REDIS_HOST=localhost for test step